### PR TITLE
Aspect blocks with typed arguments

### DIFF
--- a/Aspects.h
+++ b/Aspects.h
@@ -24,6 +24,15 @@ typedef NS_OPTIONS(NSUInteger, AspectOptions) {
 
 @end
 
+// TODO: proper name, description
+@protocol AspectInfo <NSObject>
+
+- (id)instance;
+- (NSArray *)arguments;
+- (NSInvocation *)originalInvocation;
+
+@end
+
 /**
  Aspects uses Objective-C message forwarding to hook into messages. This will create some overhead. Don't add aspects to methods that are called a lot. Aspects is meant for view/controller code that is not called a 1000 times per second.
 
@@ -33,18 +42,17 @@ typedef NS_OPTIONS(NSUInteger, AspectOptions) {
 @interface NSObject (Aspects)
 
 /// Adds a block of code before/instead/after the current `selector` for a specific class.
-/// If you choose `AspectPositionInstead`, the `arguments` array will contain the original invocation as last argument.
 /// @note Hooking static methods is not supported.
 /// @return A token which allows to later deregister the aspect.
 + (id<Aspect>)aspect_hookSelector:(SEL)selector
                       withOptions:(AspectOptions)options
-                       usingBlock:(void (^)(id instance, NSArray *args))block
+                       usingBlock:(id)block
                             error:(NSError **)error;
 
 /// Adds a block of code before/instead/after the current `selector` for a specific instance.
 - (id<Aspect>)aspect_hookSelector:(SEL)selector
                       withOptions:(AspectOptions)options
-                       usingBlock:(void (^)(id instance, NSArray *args))block
+                       usingBlock:(id)block
                             error:(NSError **)error;
 
 @end

--- a/AspectsDemo/AspectsDemo.xcodeproj/project.xcworkspace/xcshareddata/AspectsDemo.xccheckout
+++ b/AspectsDemo/AspectsDemo.xcodeproj/project.xcworkspace/xcshareddata/AspectsDemo.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>4233A0BF-3ED2-4FA2-908C-00FC08EF5EE3</string>
+	<string>DABCA236-1A56-49A0-BCD8-1DC9F6BFB1B6</string>
 	<key>IDESourceControlProjectName</key>
 	<string>AspectsDemo</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>BFDD7EB6-262A-4289-BF40-2E5B677EEC58</key>
-		<string>https://github.com/steipete/Aspects.git</string>
+		<key>312D86D6-B417-45C3-AFFE-F2D4124161B1</key>
+		<string>ssh://github.com/nickynick/Aspects.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>AspectsDemo/AspectsDemo.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>BFDD7EB6-262A-4289-BF40-2E5B677EEC58</key>
+		<key>312D86D6-B417-45C3-AFFE-F2D4124161B1</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/steipete/Aspects.git</string>
+	<string>ssh://github.com/nickynick/Aspects.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>BFDD7EB6-262A-4289-BF40-2E5B677EEC58</string>
+	<string>312D86D6-B417-45C3-AFFE-F2D4124161B1</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>BFDD7EB6-262A-4289-BF40-2E5B677EEC58</string>
+			<string>312D86D6-B417-45C3-AFFE-F2D4124161B1</string>
 			<key>IDESourceControlWCCName</key>
 			<string>Aspects</string>
 		</dict>

--- a/AspectsDemo/AspectsDemo/AspectsAppDelegate.m
+++ b/AspectsDemo/AspectsDemo/AspectsAppDelegate.m
@@ -21,11 +21,11 @@
 
     // Ignore hooks when we are testing.
     if (!NSClassFromString(@"XCTestCase")) {
-        [aspectsController aspect_hookSelector:@selector(buttonPressed:) withOptions:0 usingBlock:^(id instance, NSArray *arguments) {
-            NSLog(@"Button was pressed by: %@", arguments.firstObject);
+        [aspectsController aspect_hookSelector:@selector(buttonPressed:) withOptions:0 usingBlock:^(id info, id sender) {
+            NSLog(@"Button was pressed by: %@", sender);
         } error:NULL];
 
-        [aspectsController aspect_hookSelector:@selector(viewWillLayoutSubviews) withOptions:0 usingBlock:^(id instance, NSArray *arguments) {
+        [aspectsController aspect_hookSelector:@selector(viewWillLayoutSubviews) withOptions:0 usingBlock:^{
             NSLog(@"Controller is layouting!");
         } error:NULL];
     }

--- a/AspectsDemo/AspectsDemo/AspectsViewController.m
+++ b/AspectsDemo/AspectsDemo/AspectsViewController.m
@@ -18,16 +18,16 @@
     [self presentViewController:testController animated:YES completion:NULL];
 
     // We are interested in being notified when the controller is being dismissed.
-    [testController aspect_hookSelector:@selector(viewWillDisappear:) withOptions:0 usingBlock:^(id instance, NSArray *arguments) {
-        UIViewController *controller = instance;
+    [testController aspect_hookSelector:@selector(viewWillDisappear:) withOptions:0 usingBlock:^(id<AspectInfo> info, BOOL animated) {
+        UIViewController *controller = [info instance];
         if (controller.isBeingDismissed || controller.isMovingFromParentViewController) {
             [[[UIAlertView alloc] initWithTitle:@"Popped" message:@"Hello from Aspects" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Ok", nil] show];
         }
     } error:NULL];
 
     // Hooking dealloc is delicate, only AspectPositionBefore will work here.
-    [testController aspect_hookSelector:NSSelectorFromString(@"dealloc") withOptions:AspectPositionBefore usingBlock:^(id instance, NSArray *arguments) {
-        NSLog(@"Controller is about to be deallocated: %@", instance);
+    [testController aspect_hookSelector:NSSelectorFromString(@"dealloc") withOptions:AspectPositionBefore usingBlock:^(id<AspectInfo> info) {
+        NSLog(@"Controller is about to be deallocated: %@", [info instance]);
     } error:NULL];
 }
 


### PR DESCRIPTION
My draft implementation of #14. Seems to work fine, although not tested thoroughly yet. Here, aspect block is very liberal in terms of arguments. First potential argument could be `info`, and then all original method arguments could follow. (Or not. You may even use blocks without any arguments.)
