### PR TITLE
Fixed typo/bug in the UIViewController example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Aspects can be used to **dynamically add logging** for debug builds only:
 
 ``` objc
 [UIViewController aspect_hookSelector:@selector(viewWillAppear:) withOptions:AspectPositionAfter usingBlock:^(id<AspectInfo> aspectInfo, BOOL animated) {
-    NSLog(@"View Controller %@ will appear animated: %tu", object.instance, animated);
+    NSLog(@"View Controller %@ will appear animated: %tu", aspectInfo.instance, animated);
 } error:NULL];
 ```
 


### PR DESCRIPTION
Renamed the parameter used in the block from object to aspectInfo.
