### PR TITLE
Bugfix: cleanup didn't unswizzle classes that had already been swizzled

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -332,6 +332,8 @@ static void aspect_cleanupHookedClassAndSelector(NSObject *self, SEL selector) {
             // Class is most likely swizzled in place. Undo that.
             if (isMetaClass) {
                 aspect_undoSwizzleClassInPlace((Class)self);
+            }else if (self.class != klass) {
+            	aspect_undoSwizzleClassInPlace(klass);
             }
         }
     }


### PR DESCRIPTION
This would happen when using other code that itself swizzles classes (i.e. ReactiveCocoa). For example, if a rac_signalForSelector was called on an object then later an aspect hook was installed and further removed, we would end up in a situation where Aspect's class swizzling (in-place swizzling of -forwardInvocation:) would never be ununstalled when the last hook was removed, later wrecking havoc with RAC's own use of -forwardInvocation.

In short, this pull request fixes hair-pulling crashes.