### PR TITLE
Aspects test

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -376,13 +376,14 @@ static Class aspect_hookClass(NSObject *self, NSError **error) {
             AspectError(AspectErrorFailedToAllocateClassPair, errrorDesc);
             return nil;
         }
-
+        
 		aspect_swizzleForwardInvocation(subclass);
 		aspect_hookedGetClass(subclass, statedClass);
 		aspect_hookedGetClass(object_getClass(subclass), statedClass);
 		objc_registerClassPair(subclass);
 	}
 
+    //change isa ptr
 	object_setClass(self, subclass);
 	return subclass;
 }


### PR DESCRIPTION
##remove instance aspects

for instance method aspect_hookSelector ,when we remove the AspectInfo in aspect_cleanupHookedClassAndSelector,

if (aspect_isMsgForwardIMP(targetMethodIMP)) {
        // Restore the original method implementation.
        const char *typeEncoding = method_getTypeEncoding(targetMethod);
        SEL aliasSelector = aspect_aliasForSelector(selector);
        Method originalMethod = class_getInstanceMethod(klass, aliasSelector);
        IMP originalIMP = method_getImplementation(originalMethod);
        NSCAssert(originalMethod, @"Original implementation for %@ not found %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);

        class_replaceMethod(klass, selector, originalIMP, typeEncoding);
        AspectLog(@"Aspects: Removed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
    }
it not good ,because it will affect others . Imageing now is in A1 controller ,and hooks selector1,and then goes to A2 controllers ,(A1and A2 are instances of the same class, likes A),and also hooks selector1, now we remove the hook in selector1 in A2 controller ,as the code above , we will remove the hook in class A ,so when we return to A1,hook is invalid.So I change code to blow

```
if (aspect_isMsgForwardIMP(targetMethodIMP) && isMetaClass) {
        // Restore the original method implementation.
        const char *typeEncoding = method_getTypeEncoding(targetMethod);
        SEL aliasSelector = aspect_aliasForSelector(selector);
        Method originalMethod = class_getInstanceMethod(klass, aliasSelector);
        IMP originalIMP = method_getImplementation(originalMethod);
        if (originalIMP) {
            NSCAssert(originalMethod, @"Original implementation for %@ not found %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);
            class_replaceMethod(klass, selector, originalIMP, typeEncoding);
            AspectLog(@"Aspects: Removed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
        } else {
            AspectLog(@"Aspects: Removed hook for -[%@ %@]. but no hook", klass, NSStringFromSelector(selector));
        }
    }
```