### PR TITLE
Aspects jspatch

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -515,14 +515,11 @@ static void __ASPECTS_ARE_BEING_CALLED__(__unsafe_unretained NSObject *self, SEL
     
 
     // If no hooks are installed, call original implementation (usually to throw an exception)
+    // If no hooks are installed, call original implementation (usually to throw an exception)
     if (!respondsToAlias) {
         invocation.selector = originalSelector;
         SEL originalForwardInvocationSEL = NSSelectorFromString(AspectsForwardInvocationSelectorName);
-        if ([self respondsToSelector:originalForwardInvocationSEL]) {
-            ((void( *)(id, SEL, NSInvocation *))objc_msgSend)(self, originalForwardInvocationSEL, invocation);
-        }else {
-            [self doesNotRecognizeSelector:invocation.selector];
-        }
+        ((void( *)(id, SEL, NSInvocation *))objc_msgSend)(self, originalForwardInvocationSEL, invocation);
     }
     
     // After hooks.

--- a/Aspects.m
+++ b/Aspects.m
@@ -377,18 +377,7 @@ static Class aspect_hookClass(NSObject *self, NSError **error) {
             return nil;
         }
         
-        IMP originalImplementation = class_replaceMethod(subclass, @selector(forwardInvocation:), (IMP)__ASPECTS_ARE_BEING_CALLED__, "v@:@");
-        if (originalImplementation) {
-            class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), originalImplementation, "v@:@");
-        } else {
-            Method baseTargetMethod = class_getInstanceMethod(baseClass, @selector(forwardInvocation:));
-            IMP baseTargetMethodIMP = method_getImplementation(baseTargetMethod);
-            if (baseTargetMethodIMP) {
-                class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), baseTargetMethodIMP, "v@:@");
-                
-            }
-        }
-        //aspect_swizzleForwardInvocation(subclass);
+        aspect_swizzleForwardInvocation(subclass);
         aspect_hookedGetClass(subclass, statedClass);
         aspect_hookedGetClass(object_getClass(subclass), statedClass);
         objc_registerClassPair(subclass);

--- a/Aspects.m
+++ b/Aspects.m
@@ -369,19 +369,30 @@ static Class aspect_hookClass(NSObject *self, NSError **error) {
 	const char *subclassName = [className stringByAppendingString:AspectsSubclassSuffix].UTF8String;
 	Class subclass = objc_getClass(subclassName);
 
-	if (subclass == nil) {
-		subclass = objc_allocateClassPair(baseClass, subclassName, 0);
-		if (subclass == nil) {
+    if (subclass == nil) {
+        subclass = objc_allocateClassPair(baseClass, subclassName, 0);
+        if (subclass == nil) {
             NSString *errrorDesc = [NSString stringWithFormat:@"objc_allocateClassPair failed to allocate class %s.", subclassName];
             AspectError(AspectErrorFailedToAllocateClassPair, errrorDesc);
             return nil;
         }
-
-		aspect_swizzleForwardInvocation(subclass);
-		aspect_hookedGetClass(subclass, statedClass);
-		aspect_hookedGetClass(object_getClass(subclass), statedClass);
-		objc_registerClassPair(subclass);
-	}
+        
+        IMP originalImplementation = class_replaceMethod(subclass, @selector(forwardInvocation:), (IMP)__ASPECTS_ARE_BEING_CALLED__, "v@:@");
+        if (originalImplementation) {
+            class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), originalImplementation, "v@:@");
+        } else {
+            Method baseTargetMethod = class_getInstanceMethod(baseClass, @selector(forwardInvocation:));
+            IMP baseTargetMethodIMP = method_getImplementation(baseTargetMethod);
+            if (baseTargetMethodIMP) {
+                class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), baseTargetMethodIMP, "v@:@");
+                
+            }
+        }
+        //aspect_swizzleForwardInvocation(subclass);
+        aspect_hookedGetClass(subclass, statedClass);
+        aspect_hookedGetClass(object_getClass(subclass), statedClass);
+        objc_registerClassPair(subclass);
+    }
 
 	object_setClass(self, subclass);
 	return subclass;

--- a/Aspects.m
+++ b/Aspects.m
@@ -512,9 +512,7 @@ static void __ASPECTS_ARE_BEING_CALLED__(__unsafe_unretained NSObject *self, SEL
         }while (!respondsToAlias && (klass = class_getSuperclass(klass)));
     }
 
-    // After hooks.
-    aspect_invoke(classContainer.afterAspects, info);
-    aspect_invoke(objectContainer.afterAspects, info);
+    
 
     // If no hooks are installed, call original implementation (usually to throw an exception)
     if (!respondsToAlias) {
@@ -526,6 +524,10 @@ static void __ASPECTS_ARE_BEING_CALLED__(__unsafe_unretained NSObject *self, SEL
             [self doesNotRecognizeSelector:invocation.selector];
         }
     }
+    
+    // After hooks.
+    aspect_invoke(classContainer.afterAspects, info);
+    aspect_invoke(objectContainer.afterAspects, info);
 
     // Remove any hooks that are queued for deregistration.
     [aspectsToRemove makeObjectsPerformSelector:@selector(remove)];


### PR DESCRIPTION
##Compatible with already hooked method
For instance method aspect_hookSelector , imaging when a selector is hooked before using Aspects ( Such as jspatch  ,it replaced the original method to _objc_msgForward ,and exchange the forwardInvocation). In this conditions , when we add aspect ,we will not add aliasSelector,and just replace the  forwardInvocation. So when the method is invoked ,it will enter __ASPECTS_ARE_BEING_CALLED__ and arise error below
```
if (!respondsToAlias) {
        invocation.selector = originalSelector;
        SEL originalForwardInvocationSEL = NSSelectorFromString(AspectsForwardInvocationSelectorName);
        if ([self respondsToSelector:originalForwardInvocationSEL]) {
            ((void( *)(id, SEL, NSInvocation *))objc_msgSend)(self, originalForwardInvocationSEL, invocation);
        }else {
            [self doesNotRecognizeSelector:invocation.selector];
        }
    }
```
In order to solve this problem ,in method aspect_hookClass ,we replace some code like this
```
static Class aspect_hookClass(NSObject *self, NSError **error) {
    NSCParameterAssert(self);
	Class statedClass = self.class;
	Class baseClass = object_getClass(self);
	NSString *className = NSStringFromClass(baseClass);

    // Already subclassed
	if ([className hasSuffix:AspectsSubclassSuffix]) {
		return baseClass;

        // We swizzle a class object, not a single object.
	}else if (class_isMetaClass(baseClass)) {
        return aspect_swizzleClassInPlace((Class)self);
        // Probably a KVO'ed class. Swizzle in place. Also swizzle meta classes in place.
    }else if (statedClass != baseClass) {
        return aspect_swizzleClassInPlace(baseClass);
    }

    // Default case. Create dynamic subclass.
	const char *subclassName = [className stringByAppendingString:AspectsSubclassSuffix].UTF8String;
	Class subclass = objc_getClass(subclassName);

	if (subclass == nil) {
		subclass = objc_allocateClassPair(baseClass, subclassName, 0);
		if (subclass == nil) {
            NSString *errrorDesc = [NSString stringWithFormat:@"objc_allocateClassPair failed to allocate class %s.", subclassName];
            AspectError(AspectErrorFailedToAllocateClassPair, errrorDesc);
            return nil;
        }

        IMP originalImplementation = class_replaceMethod(subclass, @selector(forwardInvocation:), (IMP)__ASPECTS_ARE_BEING_CALLED__, "v@:@");
        if (originalImplementation) {
            class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), originalImplementation, "v@:@");
        } else {
            Method baseTargetMethod = class_getInstanceMethod(baseClass, @selector(forwardInvocation:));
            IMP baseTargetMethodIMP = method_getImplementation(baseTargetMethod);
            if (baseTargetMethodIMP) {
                class_addMethod(subclass, NSSelectorFromString(AspectsForwardInvocationSelectorName), baseTargetMethodIMP, "v@:@");
                
            }
        }
		//aspect_swizzleForwardInvocation(subclass);
		aspect_hookedGetClass(subclass, statedClass);
		aspect_hookedGetClass(object_getClass(subclass), statedClass);
		objc_registerClassPair(subclass);
	}

	object_setClass(self, subclass);
	return subclass;
}
```
add NSSelectorFromString(AspectsForwardInvocationSelectorName) in subclass and make it point to the forwardInvocation in originalClass . And some changes made in __ASPECTS_ARE_BEING_CALLED__ likes this

```
  // If no hooks are installed, call original implementation (usually to throw an exception)
    if (!respondsToAlias) {
        invocation.selector = originalSelector;
        SEL originalForwardInvocationSEL = NSSelectorFromString(AspectsForwardInvocationSelectorName);
        ((void( *)(id, SEL, NSInvocation *))objc_msgSend)(self, originalForwardInvocationSEL, invocation);
    }

    // After hooks.
    aspect_invoke(classContainer.afterAspects, info);
    aspect_invoke(objectContainer.afterAspects, info);

```
For now , when the method is invoked , we will enter  __ASPECTS_ARE_BEING_CALLED__ . Because no aliasSelector is found ,respondsToAlias is NO ,owing to the NSSelectorFromString(AspectsForwardInvocationSelectorName)  is added before , objc_msgSend will let us go to the jspatch process (here ,we will never need check respondsToSelector ,because self will not respondsToSelector while we have added NSSelectorFromString(AspectsForwardInvocationSelectorName) to subclass )
Finally we need move the aspect_invoke to blow to keep after location.

##remove instance aspects 

for instance  method aspect_hookSelector ,when we remove the AspectInfo in aspect_cleanupHookedClassAndSelector,

```
if (aspect_isMsgForwardIMP(targetMethodIMP)) {
        // Restore the original method implementation.
        const char *typeEncoding = method_getTypeEncoding(targetMethod);
        SEL aliasSelector = aspect_aliasForSelector(selector);
        Method originalMethod = class_getInstanceMethod(klass, aliasSelector);
        IMP originalIMP = method_getImplementation(originalMethod);
        NSCAssert(originalMethod, @"Original implementation for %@ not found %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);

        class_replaceMethod(klass, selector, originalIMP, typeEncoding);
        AspectLog(@"Aspects: Removed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
    }
```

it not good ,because it will affect others . Imageing now is in A1 controller ,and hooks selector1,and then goes to A2 controllers ,(A1and A2 are instances of the same class, likes A),and also hooks selector1, now we remove the hook in selector1 in A2 controller ,as the code above , we will remove the hook in class A ,so when we return to A1,hook is invalid.So I change code to blow

```
if (aspect_isMsgForwardIMP(targetMethodIMP) && isMetaClass) {
        // Restore the original method implementation.
        const char *typeEncoding = method_getTypeEncoding(targetMethod);
        SEL aliasSelector = aspect_aliasForSelector(selector);
        Method originalMethod = class_getInstanceMethod(klass, aliasSelector);
        IMP originalIMP = method_getImplementation(originalMethod);
        if (originalIMP) {
            NSCAssert(originalMethod, @"Original implementation for %@ not found %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);
            class_replaceMethod(klass, selector, originalIMP, typeEncoding);
            AspectLog(@"Aspects: Removed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
        } else {
            AspectLog(@"Aspects: Removed hook for -[%@ %@]. but no hook", klass, NSStringFromSelector(selector));
        }
    }
```