### PR TITLE
Coexistence with KVO. Yes, it works!!

### DIFF
--- a/AspectsDemo/AspectsDemoTests/AspectsDemoTests.m
+++ b/AspectsDemo/AspectsDemoTests/AspectsDemoTests.m
@@ -12,7 +12,6 @@
 
 @interface TestClass : NSObject
 @property (nonatomic, copy) NSString *string;
-@property (nonatomic, assign) BOOL kvoTestCalled;
 - (void)testCall;
 - (void)testCallAndExecuteBlock:(dispatch_block_t)block;
 - (double)callReturnsDouble;
@@ -551,10 +550,37 @@
     XCTAssertFalse([aspectToken remove], @"Must not able to deregister again");
 }
 
+@end
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Test KVO
 
+@protocol TestKVOClassProtocol <NSObject>
+@property (nonatomic, assign) BOOL kvoTestCalled;
+@end
+
+#define TestKVOClass(suffix) \
+    Test##suffix
+
+#define declareTestKVOClass(suffix) \
+    @interface TestKVOClass(suffix) : NSObject <TestKVOClassProtocol> \
+    @property (nonatomic, copy) NSString *string; \
+    @property (nonatomic, assign) BOOL kvoTestCalled; \
+    @end \
+    @implementation TestKVOClass(suffix) @end
+
+declareTestKVOClass(InstanceHookThenKVO)
+declareTestKVOClass(KVOThenInstanceHook)
+declareTestKVOClass(ClassHookThenKVO)
+declareTestKVOClass(KVOThenClassHook)
+
+@interface AspectsKVOTests : XCTestCase @end
+@implementation AspectsKVOTests
+
 - (void)testKVOCoexistance {
+#pragma push_macro( "TestClass" )
+#define TestClass TestKVOClass(InstanceHookThenKVO)
+    
     TestClass *testClass = [TestClass new];
 
     __block BOOL hookCalled = NO;
@@ -576,10 +602,15 @@
     XCTAssertFalse(testClass.kvoTestCalled, @"KVO must no longer work");
 
     XCTAssertTrue([aspectToken remove], @"Must be able to deregister");
+    
+#pragma pop_macro( "TestClass" )
 }
 
 // Pre-registeded KVO
 - (void)testKVOCoexistanceWithPreregisteredKVO {
+#pragma push_macro( "TestClass" )
+#define TestClass TestKVOClass(KVOThenInstanceHook)
+    
     TestClass *testClass = [TestClass new];
     XCTAssertFalse(testClass.kvoTestCalled, @"KVO must be not set");
     
@@ -621,10 +652,14 @@
     testClass.kvoTestCalled = NO;
     XCTAssertFalse(hookCalled, @"Hook must be not called");
     XCTAssertFalse(testClass.kvoTestCalled, @"KVO must no longer work");
+    
+#pragma pop_macro( "TestClass" )
 }
 
 #pragma mark - Test KVO with class hook
 - (void)testKVOClassHookCoexistence {
+#pragma push_macro( "TestClass" )
+#define TestClass TestKVOClass(ClassHookThenKVO)
     
     // Step 1: Class-hooking
     __block BOOL hookCalled = NO;
@@ -654,17 +689,52 @@
     XCTAssertFalse(testClass.kvoTestCalled, @"KVO must no longer work");
     
     XCTAssertTrue([aspectToken remove], @"Must be able to deregister");
+    
+#pragma pop_macro( "TestClass" )
 }
 
-// TODO: Pre-registeded KVO is currently not working.
-//- (void)testKVOClassHookCoexistenceWithPreregisteredKVO {
-//}
+// Pre-registeded KVO
+- (void)testKVOClassHookCoexistenceWithPreregisteredKVO {
+#pragma push_macro( "TestClass" )
+#define TestClass TestKVOClass(KVOThenClassHook)
+    
+    // Step 1: kvo dynamic-subclassing
+    TestClass *testClass = [TestClass new];
+    [testClass addObserver:self forKeyPath:NSStringFromSelector(@selector(string)) options:0 context:_cmd];
+    
+    // Step 2: Class-hooking
+    __block BOOL hookCalled = NO;
+    id aspectToken = [TestClass aspect_hookSelector:@selector(setString:) withOptions:AspectPositionAfter usingBlock:^(id<AspectInfo> info, NSString *string) {
+        NSLog(@"Aspect hook!");
+        hookCalled = YES;
+    } error:NULL];
+    
+    // Step 3: validation
+    XCTAssertFalse(testClass.kvoTestCalled, @"KVO must be not set");
+    
+    // Step 3.1: call w/ Observer
+    testClass.string = @"test";
+    XCTAssertTrue(hookCalled, @"Hook must be called");
+    XCTAssertTrue(testClass.kvoTestCalled, @"KVO must work");
+    
+    // Step 3.2: call w/o Observer
+    [testClass removeObserver:self forKeyPath:NSStringFromSelector(@selector(string)) context:_cmd];
+    hookCalled = NO;
+    testClass.kvoTestCalled = NO;
+    testClass.string = @"test2";
+    XCTAssertTrue(hookCalled, @"Hook must be called");
+    XCTAssertFalse(testClass.kvoTestCalled, @"KVO must no longer work");
+    
+    XCTAssertTrue([aspectToken remove], @"Must be able to deregister");
+    
+#pragma pop_macro( "TestClass" )
+}
 
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id<TestKVOClassProtocol>)object change:(NSDictionary *)change context:(void *)context {
     if (! [keyPath isEqualToString:NSStringFromSelector(@selector(kvoTestCalled))]) {
         NSLog(@"KVO!");
-        ((TestClass *)object).kvoTestCalled = YES;
+        object.kvoTestCalled = YES;
     }
 }
 


### PR DESCRIPTION
> KVO works if observers are created after your calls `aspect_hookSelector:` It most likely will crash the other way around. Still looking for workarounds here - any help appreciated.

Hi, @steipete  

I loved aspects, and I really want it can be used by everyone in every projects. But I think the KVO crash is one of limitation which block the way.

So, I have spent many times(and in many ways) to making it works, and hopefully, I got a solution:

- call original selector with the `original _cmd`

That means we need re-swizzle the `originalSelector` we saved priviously to class-isa and set `invocation.selector` with it also before calling `[invocation invoke];`

All things works like a charm.

KVO Coexistence with different aspects hook mode:

| Aspects mode  | Hook after KVO | KVO after Hook |
|:------------- |:--------------:| :-------------:|
| Class hook    | Works          | Works          |
| Instance hook | Works with one limit | Works    |

All tests above added/updated to the testCase target.

I can provide more detail about why this way has been choosen with this PR if you're interested.

One limitation:

- Instance Hook after KVO

    Doing instance hook on a KVO'ed class will trigger an in-place swizzle, then, the `forwardInvocation:` will be applied to the isa-swizzled subclass created  by KVO. Aspects will works until the isa-swizzled subclass destoryed once all observer has been removed. As our usual practice, removes all observers in `dealloc` method. This is the same logic as RAC and it's acceptable I think.

Many thanks for all your work on this project!
