### PR TITLE
Fix issue : Exc_bad_access call instance error in hook callback

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -38,8 +38,8 @@ typedef struct _AspectBlock {
 } *AspectBlockRef;
 
 @interface AspectInfo : NSObject <AspectInfo>
-- (id)initWithInstance:(__unsafe_unretained id)instance invocation:(NSInvocation *)invocation;
-@property (nonatomic, unsafe_unretained, readonly) id instance;
+- (id)initWithInstance:(__weak id)instance invocation:(NSInvocation *)invocation;
+@property (nonatomic, weak, readonly) id instance;
 @property (nonatomic, strong, readonly) NSArray *arguments;
 @property (nonatomic, strong, readonly) NSInvocation *originalInvocation;
 @end
@@ -924,7 +924,7 @@ static void aspect_deregisterTrackedSelector(id self, SEL selector) {
 
 @synthesize arguments = _arguments;
 
-- (id)initWithInstance:(__unsafe_unretained id)instance invocation:(NSInvocation *)invocation {
+- (id)initWithInstance:(__weak id)instance invocation:(NSInvocation *)invocation {
     NSCParameterAssert(instance);
     NSCParameterAssert(invocation);
     if (self = [super init]) {


### PR DESCRIPTION
Hello: 
Problem Description: when I hook the viewDidDisappear: method in the callback when I use the callback information AspectInfo instance, always exc_bad_access error, I find the source and solve the trouble, you can see
the use of unsafe_unretained'instance'in AspectInfo class modified member properties,
when the callback if the object referred to by'instance' was released at this time because of the characteristics of unsafe_unretained,
 the object to which instance points is not set to nil, exc_bad_access will eventually lead to errors when used outside,
 I modified to solve the problem for weak;
```@property (nonatomic, weak, readonly) id instance;```