### PR TITLE
fix crash on simulator iphone5s/6s/7

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -256,16 +256,16 @@ static IMP aspect_getMsgForwardIMP(NSObject *self, SEL selector) {
             NSGetSizeAndAlignment(encoding, &valueSize, NULL);
 
 #if defined(__arm__)
-            if (valueSize <= 4 ) {//arm32
+            if (valueSize == 1 ||valueSize == 2 || valueSize == 4 ) {//arm32
                 methodReturnsStructValue = NO;
             }
             
 #elif defined(__LP64__) && __LP64__
-            if (valueSize <= 16) {//x86-64
+            if (valueSize == 1 ||valueSize == 2 || valueSize == 4 ||valueSize == 8 ||valueSize == 16) {//x86-64
                 methodReturnsStructValue = NO;
             }
 #else
-            if (valueSize <= 8 ) {//IA-32
+            if (valueSize == 1 ||valueSize == 2 || valueSize == 4 ||valueSize == 8  ) {//IA-32
                 methodReturnsStructValue = NO;
             }
 #endif

--- a/Aspects.m
+++ b/Aspects.m
@@ -258,6 +258,11 @@ static IMP aspect_getMsgForwardIMP(NSObject *self, SEL selector) {
             if (valueSize == 1 || valueSize == 2 || valueSize == 4 || valueSize == 8) {
                 methodReturnsStructValue = NO;
             }
+#if defined(__LP64__) && __LP64__
+            if (valueSize == 16) {
+                methodReturnsStructValue = NO;
+            }
+#endif
         } @catch (__unused NSException *e) {}
     }
     if (methodReturnsStructValue) {

--- a/Aspects.m
+++ b/Aspects.m
@@ -255,14 +255,22 @@ static IMP aspect_getMsgForwardIMP(NSObject *self, SEL selector) {
             NSUInteger valueSize = 0;
             NSGetSizeAndAlignment(encoding, &valueSize, NULL);
 
-            if (valueSize == 1 || valueSize == 2 || valueSize == 4 || valueSize == 8) {
+#if defined(__arm__)
+            if (valueSize <= 4 ) {//arm32
                 methodReturnsStructValue = NO;
             }
-#if defined(__LP64__) && __LP64__
-            if (valueSize == 16) {
+            
+#elif defined(__LP64__) && __LP64__
+            if (valueSize <= 16) {//x86-64
+                methodReturnsStructValue = NO;
+            }
+#else
+            if (valueSize <= 8 ) {//IA-32
                 methodReturnsStructValue = NO;
             }
 #endif
+
+
         } @catch (__unused NSException *e) {}
     }
     if (methodReturnsStructValue) {


### PR DESCRIPTION
When I have some code 

```
- (CGPoint)funcToSwizzleReturnPoint:(CGPoint)point
{
    return CGPointZero;
}
```

I use Aspects:
```
    SEL selector =  NSSelectorFromString(@"funcToSwizzleReturnPoint:");
    [Obj aspect_hookSelector:selector withOptions:AspectPositionAfter usingBlock:^(id<AspectInfo> info){
        NSLog(@"aspect obj");
    } error:nil];
```

Run on simulator iphone5s/6s/7, it crash.

So. I try to add  code 
```
#if defined(__LP64__) && __LP64__
            if (valueSize == 16) {
                methodReturnsStructValue = NO;
            }
#endif
```

It work.

