### PR TITLE
Conform AspectIdentifier to AspectToken

### DIFF
--- a/Aspects.m
+++ b/Aspects.m
@@ -45,7 +45,7 @@ typedef struct _AspectBlock {
 @end
 
 // Tracks a single aspect.
-@interface AspectIdentifier : NSObject
+@interface AspectIdentifier : NSObject <AspectToken>
 + (instancetype)identifierWithSelector:(SEL)selector object:(id)object options:(AspectOptions)options block:(id)block error:(NSError **)error;
 - (BOOL)invokeWithInfo:(id<AspectInfo>)info;
 @property (nonatomic, assign) SEL selector;


### PR DESCRIPTION
If I'm not mistaken AspectIdentifier is what being returned by `aspect_hookSelector…` method
If so it's advertised that it would conform to `AspectToken` protocol
It does it in informal way (by just implementing required methods)
What it means is that if we check the object returned by `aspect_hookSelector…` method at runtime for the protocol conformance it will actually fail which can impact user logic relying on that